### PR TITLE
Add a new line to close filehandle OUT

### DIFF
--- a/GBS_fastq_Demultiplexer_v9_2Enzyme2barcode_withmismatch.pl
+++ b/GBS_fastq_Demultiplexer_v9_2Enzyme2barcode_withmismatch.pl
@@ -339,5 +339,6 @@ foreach my $file (keys %ph){
     open OUT, ">>$file";
     foreach my $read (@{$ph{$file}}){
         print OUT "$read";
+    close OUT;
     }
 }


### PR DESCRIPTION
I got this warning from the system when I was running it: "Warning: unable to close filehandle OUT properly." the modification should avoid this issue.